### PR TITLE
Attractions controller unit test

### DIFF
--- a/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
+++ b/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
@@ -7,6 +7,7 @@ import { IUpdateAttraction } from '../domain/useCases/IUpdateAttraction';
 import { IDeleteAttraction } from '../domain/useCases/IDeleteAttraction';
 import { Attractions } from '../domain/entities/attractions.entity';
 import { ResultStatus } from '../../../shared/helpers/result';
+import { UpdateAttractionDTO } from '../domain/dtos/UpdateAttractionDTO';
 
 describe('TouristAttractionsController', () => {
   let controller: TouristAttractionsController;
@@ -88,6 +89,32 @@ describe('TouristAttractionsController', () => {
     await controller.Create(response as any, new Attractions());
 
     expect(response.status).toHaveBeenCalledWith(201);
+    expect(response.json).toHaveBeenCalledWith(result);
+  });
+
+  it('should update an attraction', async () => {
+    const result = {
+      isSuccess: true,
+      content: new Attractions(),
+      message: '',
+      status: ResultStatus.OK,
+    };
+    jest.spyOn(mockUpdateAttraction, 'Execute').mockResolvedValue(result);
+
+    const updateDto: UpdateAttractionDTO = {
+      name: 'Test Park',
+      description: 'A beautiful park',
+      location: 'Center of the city',
+      averageRating: 4.5,
+      latitude: '40.712776',
+      longitude: '-74.005974',
+      updatedAt: new Date().toISOString(),
+    };
+
+    const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await controller.Update(response as any, 1, updateDto);
+
+    expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith(result);
   });
 });

--- a/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
+++ b/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
@@ -1,0 +1,45 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { TouristAttractionsController } from './touristAttractions.controller';
+import { ICreateAttraction } from '../domain/useCases/ICreateAttraction';
+import { IFindAttractionById } from '../domain/useCases/IFindAttractionById';
+import { IFindAllAttractions } from '../domain/useCases/IFindAllAttractions';
+import { IUpdateAttraction } from '../domain/useCases/IUpdateAttraction';
+import { IDeleteAttraction } from '../domain/useCases/IDeleteAttraction';
+import { Attractions } from '../domain/entities/attractions.entity';
+import { ResultStatus } from '../../../shared/helpers/result';
+
+describe('TouristAttractionsController', () => {
+  let controller: TouristAttractionsController;
+  let mockCreateAttraction: ICreateAttraction;
+  let mockFindAttractionById: IFindAttractionById;
+  let mockFindAllAttractions: IFindAllAttractions;
+  let mockUpdateAttraction: IUpdateAttraction;
+  let mockDeleteAttraction: IDeleteAttraction;
+
+  beforeEach(async () => {
+    mockCreateAttraction = { Execute: jest.fn() };
+    mockFindAttractionById = { Execute: jest.fn() };
+    mockFindAllAttractions = { Execute: jest.fn() };
+    mockUpdateAttraction = { Execute: jest.fn() };
+    mockDeleteAttraction = { Execute: jest.fn() };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [TouristAttractionsController],
+      providers: [
+        { provide: ICreateAttraction, useValue: mockCreateAttraction },
+        { provide: IFindAttractionById, useValue: mockFindAttractionById },
+        { provide: IFindAllAttractions, useValue: mockFindAllAttractions },
+        { provide: IUpdateAttraction, useValue: mockUpdateAttraction },
+        { provide: IDeleteAttraction, useValue: mockDeleteAttraction },
+      ],
+    }).compile();
+
+    controller = module.get<TouristAttractionsController>(
+      TouristAttractionsController,
+    );
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
+++ b/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
@@ -58,4 +58,20 @@ describe('TouristAttractionsController', () => {
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith(result);
   });
+
+  it('should get an attraction by id', async () => {
+    const result = {
+      isSuccess: true,
+      content: new Attractions(),
+      message: '',
+      status: ResultStatus.OK,
+    };
+    jest.spyOn(mockFindAttractionById, 'Execute').mockResolvedValue(result);
+
+    const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await controller.GetById(response as any, 1);
+
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith(result);
+  });
 });

--- a/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
+++ b/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
@@ -45,6 +45,7 @@ describe('TouristAttractionsController', () => {
   });
 
   it('should get all attractions', async () => {
+    // Arrange
     const result = {
       isSuccess: true,
       content: [new Attractions()],
@@ -53,14 +54,17 @@ describe('TouristAttractionsController', () => {
     };
     jest.spyOn(mockFindAllAttractions, 'Execute').mockResolvedValue(result);
 
+    // Act
     const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await controller.GetAll(response as any);
 
+    // Assert
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith(result);
   });
 
   it('should get an attraction by id', async () => {
+    // Arrange
     const result = {
       isSuccess: true,
       content: new Attractions(),
@@ -69,14 +73,17 @@ describe('TouristAttractionsController', () => {
     };
     jest.spyOn(mockFindAttractionById, 'Execute').mockResolvedValue(result);
 
+    // Act
     const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await controller.GetById(response as any, 1);
 
+    // Assert
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith(result);
   });
 
   it('should create an attraction', async () => {
+    // Arrange
     const result = {
       isSuccess: true,
       content: new Attractions(),
@@ -85,14 +92,17 @@ describe('TouristAttractionsController', () => {
     };
     jest.spyOn(mockCreateAttraction, 'Execute').mockResolvedValue(result);
 
+    // Act
     const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await controller.Create(response as any, new Attractions());
 
+    // Assert
     expect(response.status).toHaveBeenCalledWith(201);
     expect(response.json).toHaveBeenCalledWith(result);
   });
 
   it('should update an attraction', async () => {
+    // Arrange
     const result = {
       isSuccess: true,
       content: new Attractions(),
@@ -111,9 +121,30 @@ describe('TouristAttractionsController', () => {
       updatedAt: new Date().toISOString(),
     };
 
+    // Act
     const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
     await controller.Update(response as any, 1, updateDto);
 
+    // Assert
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith(result);
+  });
+
+  it('should delete an attraction', async () => {
+    // Arrange
+    const result = {
+      isSuccess: true,
+      content: true,
+      message: '',
+      status: ResultStatus.OK,
+    };
+    jest.spyOn(mockDeleteAttraction, 'Execute').mockResolvedValue(result);
+
+    // Act
+    const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await controller.Remove(response as any, 1);
+
+    // Assert
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith(result);
   });

--- a/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
+++ b/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
@@ -42,4 +42,20 @@ describe('TouristAttractionsController', () => {
   it('should be defined', () => {
     expect(controller).toBeDefined();
   });
+
+  it('should get all attractions', async () => {
+    const result = {
+      isSuccess: true,
+      content: [new Attractions()],
+      message: '',
+      status: ResultStatus.OK,
+    };
+    jest.spyOn(mockFindAllAttractions, 'Execute').mockResolvedValue(result);
+
+    const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await controller.GetAll(response as any);
+
+    expect(response.status).toHaveBeenCalledWith(200);
+    expect(response.json).toHaveBeenCalledWith(result);
+  });
 });

--- a/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
+++ b/backend/src/touristAttractions/presentation/touristAttractions.controller.spec.ts
@@ -74,4 +74,20 @@ describe('TouristAttractionsController', () => {
     expect(response.status).toHaveBeenCalledWith(200);
     expect(response.json).toHaveBeenCalledWith(result);
   });
+
+  it('should create an attraction', async () => {
+    const result = {
+      isSuccess: true,
+      content: new Attractions(),
+      message: '',
+      status: ResultStatus.CREATED,
+    };
+    jest.spyOn(mockCreateAttraction, 'Execute').mockResolvedValue(result);
+
+    const response = { status: jest.fn().mockReturnThis(), json: jest.fn() };
+    await controller.Create(response as any, new Attractions());
+
+    expect(response.status).toHaveBeenCalledWith(201);
+    expect(response.json).toHaveBeenCalledWith(result);
+  });
 });

--- a/backend/src/touristAttractions/presentation/touristAttractions.controller.ts
+++ b/backend/src/touristAttractions/presentation/touristAttractions.controller.ts
@@ -1,4 +1,4 @@
-import { HttpHelper } from 'shared/helpers/httpResponseHelper';
+import { HttpHelper } from '../../../shared/helpers/httpResponseHelper';
 import {
   Controller,
   Get,


### PR DESCRIPTION
## Description
This pull request adds unit tests for the `TouristAttractionsController`. The tests cover the following controller methods:

- `GetAll`: Tests retrieving all tourist attractions.
- `GetById`: Tests retrieving a tourist attraction by ID.
- `Create`: Tests creating a new tourist attraction.
- `Update`: Tests updating an existing tourist attraction.
- `Remove`: Tests deleting a tourist attraction.

The `TouristAttractionsController `unit tests have a 100% of coverage as seen in the image below:

![image](https://github.com/user-attachments/assets/e0031e6e-1a78-46a4-8592-6dee059e0970)

## Changes
Created the touristAttractions.controller.spec.ts file with unit tests.

## How to Test

1. Run the tests using the command `npm run test`
2. Check that all tests pass without errors.
3. See the coverage with `npm test -- --coverage`
4. The coverage for `TouristAttractionsController` should be 100%